### PR TITLE
QGIS 4 / Qt6 support, v1.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install ruff pytest
+      - name: Syntax check
+        run: python -m compileall -q __init__.py main_dialog.py polyline.py
+      - name: Lint
+        run: ruff check .
+      - name: Tests
+        run: pytest -q

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Three-file core, each with a clear role:
 
 - `__init__.py` — QGIS plugin entry point. `classFactory(iface)` returns `EncodedPolylinePlugin`, which registers a single toolbar action. The dialog is imported lazily inside `open_main_dialog` so QGIS startup stays cheap.
 - `main_dialog.py` — `MainDialog` (QDialog) loaded from `main_dialog.ui` via `uic.loadUiType`. Owns all UI logic: reads the encoded string + precision from the form, calls `polyline.decode`, builds a `QgsVectorLayer` (memory provider, LineString, EPSG:4326), adds a single `QgsFeature` with a `QgsGeometry.fromPolylineXY([QgsPointXY(lon, lat), ...])`, applies `redLineStyle.qml`, and adds the layer to `QgsProject.instance()`. The module-level `EXAMPLES` list populates the sample dropdown.
-- `polyline.py` — vendored copy of https://github.com/frederickjansen/polyline (`PolylineCodec` + module-level `decode`/`encode`). Depends on `six`. Coordinates returned as `(lat, lon)` tuples unless `geojson=True`. Do not refactor casually — keep upstream-compatible.
+- `polyline.py` — vendored copy of https://github.com/frederickjansen/polyline (`PolylineCodec` + module-level `decode`/`encode`), de-`six`-ified for Python 3 only. Coordinates returned as `(lat, lon)` tuples unless `geojson=True`. Do not refactor casually — keep upstream-compatible.
 
 Coordinate ordering is the easiest place to introduce a bug: `polyline.decode` returns `(lat, lon)`, but `QgsPointXY` takes `(x, y) = (lon, lat)`. Any code touching the decode → geometry path must swap.
 
@@ -31,4 +31,4 @@ Coordinate ordering is the easiest place to introduce a bug: `polyline.decode` r
 ## Conventions
 
 - Precision: Google Maps uses 5, OpenStreetMap/Valhalla uses 6. The dialog exposes this; don't hardcode.
-- Python is QGIS' bundled interpreter (PyQt5 + `qgis.core`). Don't add dependencies that aren't already shipped with QGIS — `six` is the only third-party module currently vendored, via `polyline.py`.
+- Python is QGIS' bundled interpreter; the plugin runs on QGIS 3 (Qt5) and QGIS 4 (Qt6). Always import Qt classes via `qgis.PyQt.*` (never `PyQt5.*` directly) and use the scoped enum form (e.g. `QDialogButtonBox.StandardButton.Reset`, not `QDialogButtonBox.Reset`) so the same code works on both. `metadata.txt` declares `supportsQt6=True`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A QGIS 3 plugin that decodes Google/OSM-style encoded polylines and loads them as in-memory vector layers. It is loaded by QGIS, not run standalone — there is no `pip install`, no test suite, and no entry point besides QGIS calling `classFactory(iface)` in `__init__.py`.
+
+## Common commands
+
+- **Package for distribution / QGIS plugin install**: `./package.sh` — produces `encoded-polyline.zip` from the current `HEAD` via `git archive` (so commit changes before packaging; uncommitted files are not included).
+- **Local install for development**: symlink or copy the repo directory into the QGIS plugins folder, e.g. `~/.local/share/QGIS/QGIS3/profiles/default/python/plugins/encoded-polyline`, then enable "Encoded Polyline" in QGIS' Plugin Manager. Use the *Plugin Reloader* plugin to pick up code changes without restarting QGIS.
+
+## Architecture
+
+Three-file core, each with a clear role:
+
+- `__init__.py` — QGIS plugin entry point. `classFactory(iface)` returns `EncodedPolylinePlugin`, which registers a single toolbar action. The dialog is imported lazily inside `open_main_dialog` so QGIS startup stays cheap.
+- `main_dialog.py` — `MainDialog` (QDialog) loaded from `main_dialog.ui` via `uic.loadUiType`. Owns all UI logic: reads the encoded string + precision from the form, calls `polyline.decode`, builds a `QgsVectorLayer` (memory provider, LineString, EPSG:4326), adds a single `QgsFeature` with a `QgsGeometry.fromPolylineXY([QgsPointXY(lon, lat), ...])`, applies `redLineStyle.qml`, and adds the layer to `QgsProject.instance()`. The module-level `EXAMPLES` list populates the sample dropdown.
+- `polyline.py` — vendored copy of https://github.com/frederickjansen/polyline (`PolylineCodec` + module-level `decode`/`encode`). Depends on `six`. Coordinates returned as `(lat, lon)` tuples unless `geojson=True`. Do not refactor casually — keep upstream-compatible.
+
+Coordinate ordering is the easiest place to introduce a bug: `polyline.decode` returns `(lat, lon)`, but `QgsPointXY` takes `(x, y) = (lon, lat)`. Any code touching the decode → geometry path must swap.
+
+## Supporting files
+
+- `main_dialog.ui` — Qt Designer form. Edit in Designer; do not hand-edit unless the change is trivial.
+- `redLineStyle.qml` — QGIS layer style applied to every created layer.
+- `metadata.txt` — QGIS plugin manifest (name, version, `qgisMinimumVersion`). Bump `version=` here when releasing.
+- `encodedPolyline.svg` — toolbar icon, referenced by both `__init__.py` and `metadata.txt`.
+
+## Conventions
+
+- Precision: Google Maps uses 5, OpenStreetMap/Valhalla uses 6. The dialog exposes this; don't hardcode.
+- Python is QGIS' bundled interpreter (PyQt5 + `qgis.core`). Don't add dependencies that aren't already shipped with QGIS — `six` is the only third-party module currently vendored, via `polyline.py`.

--- a/__init__.py
+++ b/__init__.py
@@ -10,8 +10,8 @@
 # ---------------------------------------------------------------------
 
 import os
-from PyQt5.QtWidgets import QAction, QMessageBox
-from PyQt5.QtGui import QIcon
+from qgis.PyQt.QtWidgets import QAction
+from qgis.PyQt.QtGui import QIcon
 
 
 def classFactory(iface):
@@ -41,4 +41,4 @@ class EncodedPolylinePlugin:
         from .main_dialog import MainDialog
 
         dialog = MainDialog(parent=self.iface.mainWindow(), iface=self.iface)
-        dialog.exec_()  # modal
+        dialog.exec()  # modal

--- a/main_dialog.py
+++ b/main_dialog.py
@@ -1,7 +1,7 @@
 import os
 import codecs
 
-from qgis.PyQt import QtCore, uic, Qt
+from qgis.PyQt import uic
 from qgis.PyQt.QtWidgets import QDialog, QDialogButtonBox
 from qgis.core import (
     QgsMessageLog,
@@ -13,7 +13,7 @@ from qgis.core import (
     QgsPointXY,
 )
 
-import polyline
+from . import polyline
 
 
 def get_ui_class(ui_file):
@@ -57,7 +57,7 @@ class MainDialog(QDialog, FORM_CLASS):
         self.buttonBox.accepted.connect(self.load_polyline)
         self.buttonBox.accepted.connect(self.accept)
         self.buttonBox.rejected.connect(self.reject)
-        self.buttonBox.button(QDialogButtonBox.Reset).clicked.connect(self.clear)
+        self.buttonBox.button(QDialogButtonBox.StandardButton.Reset).clicked.connect(self.clear)
         self.randomSamplePushButton.clicked.connect(self.load_random_sample)
         self.current_sample = 0
 

--- a/main_dialog.py
+++ b/main_dialog.py
@@ -4,8 +4,6 @@ import codecs
 from qgis.PyQt import uic
 from qgis.PyQt.QtWidgets import QDialog, QDialogButtonBox
 from qgis.core import (
-    QgsMessageLog,
-    Qgis,
     QgsVectorLayer,
     QgsFeature,
     QgsProject,

--- a/metadata.txt
+++ b/metadata.txt
@@ -2,10 +2,16 @@
 name=Encoded Polyline
 description=Encoded Polyline is a plugin to easily show encoded polyline into QGIS.
 about=Encoded Polyline is a plugin to easily show encoded polyline into QGIS.
-version=1.0
+version=1.0.0
 supportsQt6=True
 qgisMinimumVersion=3.0
 qgisMaximumVersion=4.99
+changelog=1.0.0
+    - Add QGIS 4 / Qt6 support
+    - Drop the vendored `six` dependency
+    - Package only the files needed for the plugin upload
+ 0.9
+    - Initial public release
 author=Ismail Sunni
 email=imajimatika@gmail.com
 repository=https://github.com/ismailsunni/qgis-encoded-polyline

--- a/metadata.txt
+++ b/metadata.txt
@@ -2,8 +2,10 @@
 name=Encoded Polyline
 description=Encoded Polyline is a plugin to easily show encoded polyline into QGIS.
 about=Encoded Polyline is a plugin to easily show encoded polyline into QGIS.
-version=0.9
+version=1.0
+supportsQt6=True
 qgisMinimumVersion=3.0
+qgisMaximumVersion=4.99
 author=Ismail Sunni
 email=imajimatika@gmail.com
 repository=https://github.com/ismailsunni/qgis-encoded-polyline

--- a/package.sh
+++ b/package.sh
@@ -1,1 +1,9 @@
-rm -f encoded-polyline.zip && git archive --prefix=encoded-polyline/ -o encoded-polyline.zip HEAD
+rm -f encoded-polyline.zip && git archive --prefix=encoded-polyline/ -o encoded-polyline.zip HEAD \
+    __init__.py \
+    main_dialog.py \
+    main_dialog.ui \
+    polyline.py \
+    metadata.txt \
+    redLineStyle.qml \
+    encodedPolyline.svg \
+    LICENSE

--- a/polyline.py
+++ b/polyline.py
@@ -1,13 +1,13 @@
 # Taken from https://github.com/frederickjansen/polyline
 
+import io
 import itertools
-import six
 import math
 
 
 class PolylineCodec(object):
     def _pcitr(self, iterable):
-        return six.moves.zip(iterable, itertools.islice(iterable, 1, None))
+        return zip(iterable, itertools.islice(iterable, 1, None))
 
     def _py2_round(self, x):
         # The polyline algorithm uses Python 2's way of rounding
@@ -21,10 +21,10 @@ class PolylineCodec(object):
         coord = coord if coord >= 0 else ~coord
 
         while coord >= 0x20:
-            output.write(six.unichr((0x20 | (coord & 0x1F)) + 63))
+            output.write(chr((0x20 | (coord & 0x1F)) + 63))
             coord >>= 5
 
-        output.write(six.unichr(coord + 63))
+        output.write(chr(coord + 63))
 
     def _trans(self, value, index):
         byte, result, shift = None, 0, 0
@@ -64,7 +64,7 @@ class PolylineCodec(object):
         if geojson is True:
             coordinates = [t[::-1] for t in coordinates]
 
-        output, factor = six.StringIO(), int(10 ** precision)
+        output, factor = io.StringIO(), int(10 ** precision)
 
         self._write(output, coordinates[0][0], 0, factor)
         self._write(output, coordinates[0][1], 0, factor)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--import-mode=importlib --confcutdir=tests"
+
+[tool.ruff]
+exclude = ["polyline.py"]

--- a/tests/test_polyline.py
+++ b/tests/test_polyline.py
@@ -1,0 +1,42 @@
+import importlib.util
+import os
+
+_POLYLINE_PATH = os.path.join(os.path.dirname(__file__), "..", "polyline.py")
+_spec = importlib.util.spec_from_file_location("polyline", _POLYLINE_PATH)
+polyline = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(polyline)
+
+decode = polyline.decode
+encode = polyline.encode
+
+
+GOOGLE_EXAMPLE_ENCODED = "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
+GOOGLE_EXAMPLE_COORDS = [(38.5, -120.2), (40.7, -120.95), (43.252, -126.453)]
+
+
+def test_decode_google_example():
+    assert decode(GOOGLE_EXAMPLE_ENCODED) == GOOGLE_EXAMPLE_COORDS
+
+
+def test_encode_google_example():
+    assert encode(GOOGLE_EXAMPLE_COORDS) == GOOGLE_EXAMPLE_ENCODED
+
+
+def test_roundtrip_precision_5():
+    coords = [(38.5, -120.2), (40.7, -120.95), (43.252, -126.453)]
+    assert decode(encode(coords)) == coords
+
+
+def test_roundtrip_precision_6():
+    coords = [(38.5, -120.2), (40.7, -120.95), (43.252, -126.453)]
+    encoded = encode(coords, precision=6)
+    assert decode(encoded, precision=6) == coords
+
+
+def test_decode_geojson_swaps_to_lon_lat():
+    result = decode(GOOGLE_EXAMPLE_ENCODED, geojson=True)
+    assert result == [(lon, lat) for (lat, lon) in GOOGLE_EXAMPLE_COORDS]
+
+
+def test_decode_empty_string():
+    assert decode("") == []


### PR DESCRIPTION
## Summary
- Add QGIS 4 / Qt6 support: switch to `qgis.PyQt.*` imports, scoped enums, `exec()`; declare `supportsQt6=True` and `qgisMaximumVersion=4.99`
- Drop the vendored `six` dependency from `polyline.py` (Python 3 only)
- Fix module loading under QGIS 4 by using a relative `from . import polyline`
- Package only the files needed for the plugin upload
- Bump version to 1.0.0 with a changelog entry in `metadata.txt`

## Test plan
- [ ] Load the plugin in QGIS 3 (Qt5), decode a sample polyline, click Reset
- [ ] Load the plugin in QGIS 4 (Qt6), decode a sample polyline, click Reset
- [ ] Run `./package.sh` and inspect `encoded-polyline.zip` contains only plugin runtime files + LICENSE

🤖 Generated with [Claude Code](https://claude.com/claude-code)