### PR TITLE
Fix plugin metadata for QGIS plugin repo upload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,4 +31,4 @@ Coordinate ordering is the easiest place to introduce a bug: `polyline.decode` r
 ## Conventions
 
 - Precision: Google Maps uses 5, OpenStreetMap/Valhalla uses 6. The dialog exposes this; don't hardcode.
-- Python is QGIS' bundled interpreter; the plugin runs on QGIS 3 (Qt5) and QGIS 4 (Qt6). Always import Qt classes via `qgis.PyQt.*` (never `PyQt5.*` directly) and use the scoped enum form (e.g. `QDialogButtonBox.StandardButton.Reset`, not `QDialogButtonBox.Reset`) so the same code works on both. `metadata.txt` declares `supportsQt6=True`.
+- Python is QGIS' bundled interpreter; the plugin runs on QGIS 3 (Qt5) and QGIS 4 (Qt6). Always import Qt classes via `qgis.PyQt.*` (never `PyQt5.*` directly) and use the scoped enum form (e.g. `QDialogButtonBox.StandardButton.Reset`, not `QDialogButtonBox.Reset`) so the same code works on both. `metadata.txt` declares `qgisMaximumVersion=4.99` to opt into the QGIS 4 Ready list.

--- a/metadata.txt
+++ b/metadata.txt
@@ -3,7 +3,6 @@ name=Encoded Polyline
 description=Encoded Polyline is a plugin to easily show encoded polyline into QGIS.
 about=Encoded Polyline is a plugin to easily show encoded polyline into QGIS.
 version=1.0.0
-supportsQt6=True
 qgisMinimumVersion=3.0
 qgisMaximumVersion=4.99
 changelog=1.0.0

--- a/metadata.txt
+++ b/metadata.txt
@@ -15,4 +15,6 @@ changelog=1.0.0
 author=Ismail Sunni
 email=imajimatika@gmail.com
 repository=https://github.com/ismailsunni/qgis-encoded-polyline
+tracker=https://github.com/ismailsunni/qgis-encoded-polyline/issues
+homepage=https://github.com/ismailsunni/qgis-encoded-polyline
 icon=./encodedPolyline.svg


### PR DESCRIPTION
## Summary
- Add `tracker` and `homepage` fields to `metadata.txt` — required by the QGIS plugin repository validator (fixes the "Cannot find metadata tracker" upload error)
- Remove `supportsQt6=True`, which the [QGIS 4 migration guide](https://plugins.qgis.org/docs/migrate-qgis4) states is no longer recognized; `qgisMaximumVersion=4.99` alone is what enrolls the plugin in the QGIS 4 Ready list

## Test plan
- [ ] Run `./package.sh` and re-upload `encoded-polyline.zip` to plugins.qgis.org — validator should accept it

🤖 Generated with [Claude Code](https://claude.com/claude-code)